### PR TITLE
Remove unnecessary idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-# Created by .ignore support plugin (hsz.mobi)
-.idea/*

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
Changes I've made:
- .idea folder was added to repository. This folder is automatically created by Intellij IDEA IDE and shouldn't be as part of the repository
- .idea folder was actually listed in .gitignore. However this doesn't work if the folder is already pushed to repostitory

Why I removed the .idea line from the .gitignore?

- It is best practice, that .gitignore should only have things that are relevant to project itself. For example if the system creates temp files, those should be gitignored. However all those things that are relevant to tools the user has chosen, for example IDE, should not be added to project .gitignore, but that person's own global .gitignore file.

Before accepting this pull request do following:
- First copy the .idea folder to somewhere safe just in case
- Add the .idea to your global .gitignore file (https://help.github.com/articles/ignoring-files/ -> Create a global .gitignore file)
- Accept pull request
- Then copy the .idea folder back, if it doesn't get automatically recreated

The outcome:
- .idea folder is in place and everything works as they worked before
- But .idea folder is not added to git repository, as it shouldn't
- As you have global .gitignore file with the .idea excluding rule, the .idea folder is never added to any repositories anymore (which is good)